### PR TITLE
Improve Degeneration card

### DIFF
--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1630,6 +1630,7 @@ static void _degeneration_card(int power)
                if (mons.can_polymorph())
                {
                    mons.polymorph(PPT_LESS);
+                   mons.hit_points -= mons.hit_points * power_level / 5;
                    mons.malmutate("");
                }
                else


### PR DESCRIPTION
This card has an interesting and tactical effect. Although powerful, it is the least predictable of all the cards with Wild Magic card. It also has the potential to pose the most lethal danger from any wrong result of the cards. By adding new features, I want to give players the option to try a challenge rather than run away from more dangerous change enemies.  Also, This function destroys the enemy directly, so it would be more appropriate for the name of the deck of destruction.
New feature: reduce an enemy's HP by (card's power level / 5 * 100)%. 20% for level 1, 40% for level 2.